### PR TITLE
fixed the problem for same name of multiple child nodes

### DIFF
--- a/src/XmlToArray.php
+++ b/src/XmlToArray.php
@@ -60,7 +60,7 @@ class XmlToArray
         $sameNames = false;
         $result = $this->convertAttributes($element->attributes);
 
-        if (count($element->childNodes) > 1) {
+        if ($element->childNodes->length > 1) {
             $childNodeNames = [];
             foreach ($element->childNodes as $key => $node) {
                 $childNodeNames[] = $node->nodeName;

--- a/src/XmlToArray.php
+++ b/src/XmlToArray.php
@@ -81,7 +81,6 @@ class XmlToArray
             if ($node instanceof DOMElement) {
 
                 if( $sameNames ) {
-                    $indexName = $node->nodeName.($key + 1) ;
                     $result[$node->nodeName][$key] = $this->convertDomElement($node);
                 } else {
                     $result[$node->nodeName] = $this->convertDomElement($node);

--- a/src/XmlToArray.php
+++ b/src/XmlToArray.php
@@ -67,7 +67,7 @@ class XmlToArray
             $sameNames = $this->isHomogenous($childNodeNames);
         }
 
-        foreach ($element->childNodes as $node) {
+        foreach ($element->childNodes as $key => $node) {
             if ($node instanceof DOMCdataSection) {
                 $result['_cdata'] = $node->data;
 
@@ -79,7 +79,13 @@ class XmlToArray
                 continue;
             }
             if ($node instanceof DOMElement) {
-                $result[$node->nodeName] = $this->convertDomElement($node);
+
+                if( $sameNames ) {
+                    $indexName = $node->nodeName.($key + 1) ;
+                    $result[$node->nodeName][$key] = $this->convertDomElement($node);
+                } else {
+                    $result[$node->nodeName] = $this->convertDomElement($node);
+                }
 
                 continue;
             }

--- a/src/XmlToArray.php
+++ b/src/XmlToArray.php
@@ -44,7 +44,8 @@ class XmlToArray
         return ['_attributes' => $result];
     }
 
-    protected function isHomogenous(Array $arr) {
+    protected function isHomogenous(array $arr)
+    {
         $firstValue = current($arr);
         foreach ($arr as $val) {
             if ($firstValue !== $val) {
@@ -59,7 +60,7 @@ class XmlToArray
         $sameNames = false;
         $result = $this->convertAttributes($element->attributes);
 
-        if( count($element->childNodes)  > 1){
+        if (count($element->childNodes) > 1) {
             $childNodeNames = [];
             foreach ($element->childNodes as $key => $node) {
                 $childNodeNames[] = $node->nodeName;
@@ -80,7 +81,7 @@ class XmlToArray
             }
             if ($node instanceof DOMElement) {
 
-                if( $sameNames ) {
+                if ($sameNames) {
                     $result[$node->nodeName][$key] = $this->convertDomElement($node);
                 } else {
                     $result[$node->nodeName] = $this->convertDomElement($node);

--- a/src/XmlToArray.php
+++ b/src/XmlToArray.php
@@ -44,9 +44,28 @@ class XmlToArray
         return ['_attributes' => $result];
     }
 
+    protected function isHomogenous(Array $arr) {
+        $firstValue = current($arr);
+        foreach ($arr as $val) {
+            if ($firstValue !== $val) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     protected function convertDomElement(DOMElement $element)
     {
+        $sameNames = false;
         $result = $this->convertAttributes($element->attributes);
+
+        if( count($element->childNodes)  > 1){
+            $childNodeNames = [];
+            foreach ($element->childNodes as $key => $node) {
+                $childNodeNames[] = $node->nodeName;
+            }
+            $sameNames = $this->isHomogenous($childNodeNames);
+        }
 
         foreach ($element->childNodes as $node) {
             if ($node instanceof DOMCdataSection) {

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -1,9 +1,13 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Vyuldashev\XmlToArray\Test;
+
 use PHPUnit\Framework\TestCase;
 use Spatie\ArrayToXml\ArrayToXml;
 use Vyuldashev\XmlToArray\XmlToArray;
+
 class XmlToArrayTest extends TestCase
 {
     /** @dataProvider data
@@ -60,13 +64,14 @@ class XmlToArrayTest extends TestCase
         ];
     }
 
-    /** @test data
-    * /** @dataProvider sameNameData
-     * @param xml $xml
+    /** @dataProvider sameNameData
+     * @param array $array
+     * @test
      */
     public function sameNameTest(array $array)
     {
         $xml = ArrayToXml::convert($array, 'items');
+        $convertedArr = XmlToArray::convert($xml);
         $this->assertSame(['items' => $array], XmlToArray::convert($xml));
     }
 
@@ -76,41 +81,23 @@ class XmlToArrayTest extends TestCase
             [
                 [
                     'Facilities' => [
-                                'Facility' => [
-                                    [
-                                        '_attributes' => [
-                                                'Code' => '*EC',
-                                            ],
-                                        '_cdata' => 'Earliest check-in at 14:00 ',
-                                    ],
-                                    [
-                                        '_attributes' => [
-                                                'Code' => '*LF',
-                                            ],
-                                        '_cdata' => '1 lift ',
-                                    ],
-                                    [
-                                        '_attributes' => [
-                                                'Code' => '*RS',
-                                            ],
-                                        '_cdata' => 'Room Service from 18:00 to 21:00 ',
-                                    ],
-                                    [
-                                        '_attributes' => [
-                                                'Code' => '*IN',
-                                            ],
-                                        '_cdata' => 'Internet via television ',
-                                    ],
-                                    [
-                                        '_attributes' => [
-                                                'Code' => '*AC',
-                                            ],
-                                        '_cdata' => 'Air conditioning ',
-                                    ],
-                                ],
+                        'Facility' => [
+                            [
+                                '_attributes' => ['Code'=>'*EC'],
+                                '_cdata' =>  'Earliest check-in at 14:00',
+                            ],
+                            [
+                                '_attributes' => ['Code'=>'*LF'],
+                                '_cdata' =>  '1 lift',
+                            ],
+                            [
+                                '_attributes' => ['Code'=>'*RS'],
+                                '_cdata' =>  'Room Service from 18:00 to 21:00',
+                            ],
+                        ],
                     ],
                 ],
-            ],
+            ]
         ];
     }
 }

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -61,7 +61,7 @@ class XmlToArrayTest extends TestCase
     }
 
     /** @test data
-    /** @dataProvider sameNameData
+    * /** @dataProvider sameNameData
      * @param xml $xml
      */
     public function sameNameTest(array $array)
@@ -75,43 +75,42 @@ class XmlToArrayTest extends TestCase
         return [
             [
                 [
-                    'Facilities' => 
-                        [
-                            'Facility' => [
-                                [
-                                    '_attributes' => [
-                                            'Code' => '*EC'
-                                        ],
-                                    '_cdata' => 'Earliest check-in at 14:00 '
+                    'Facilities' => [
+                                'Facility' => [
+                                    [
+                                        '_attributes' => [
+                                                'Code' => '*EC',
+                                            ],
+                                        '_cdata' => 'Earliest check-in at 14:00 ',
+                                    ],
+                                    [
+                                        '_attributes' => [
+                                                'Code' => '*LF',
+                                            ],
+                                        '_cdata' => '1 lift ',
+                                    ],
+                                    [
+                                        '_attributes' => [
+                                                'Code' => '*RS',
+                                            ],
+                                        '_cdata' => 'Room Service from 18:00 to 21:00 ',
+                                    ],
+                                    [
+                                        '_attributes' => [
+                                                'Code' => '*IN',
+                                            ],
+                                        '_cdata' => 'Internet via television ',
+                                    ],
+                                    [
+                                        '_attributes' => [
+                                                'Code' => '*AC',
+                                            ],
+                                        '_cdata' => 'Air conditioning ',
+                                    ],
                                 ],
-                                [
-                                    '_attributes' => [
-                                            'Code' => '*LF'
-                                        ],
-                                    '_cdata' => '1 lift '
-                                ],
-                                [
-                                    '_attributes' => [
-                                            'Code' => '*RS'
-                                        ],
-                                    '_cdata' => 'Room Service from 18:00 to 21:00 '
-                                ],
-                                [
-                                    '_attributes' => [
-                                            'Code' => '*IN'
-                                        ],
-                                    '_cdata' => 'Internet via television '
-                                ],
-                                [
-                                    '_attributes' => [
-                                            'Code' => '*AC'
-                                        ],
-                                    '_cdata' => 'Air conditioning '
-                                ],
-                            ]
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
     }
 }

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -1,13 +1,9 @@
 <?php
-
 declare(strict_types=1);
-
 namespace Vyuldashev\XmlToArray\Test;
-
 use PHPUnit\Framework\TestCase;
 use Spatie\ArrayToXml\ArrayToXml;
 use Vyuldashev\XmlToArray\XmlToArray;
-
 class XmlToArrayTest extends TestCase
 {
     /** @dataProvider data
@@ -16,7 +12,6 @@ class XmlToArrayTest extends TestCase
     public function test(array $array)
     {
         $xml = ArrayToXml::convert($array, 'items');
-
         $this->assertSame(['items' => $array], XmlToArray::convert($xml));
     }
 
@@ -62,6 +57,61 @@ class XmlToArrayTest extends TestCase
                     ],
                 ],
             ],
+        ];
+    }
+
+    /** @test data
+    /** @dataProvider sameNameData
+     * @param xml $xml
+     */
+    public function sameNameTest(array $array)
+    {
+        $xml = ArrayToXml::convert($array, 'items');
+        $this->assertSame(['items' => $array], XmlToArray::convert($xml));
+    }
+
+    public function sameNameData()
+    {
+        return [
+            [
+                [
+                    'Facilities' => 
+                        [
+                            'Facility' => [
+                                [
+                                    '_attributes' => [
+                                            'Code' => '*EC'
+                                        ],
+                                    '_cdata' => 'Earliest check-in at 14:00 '
+                                ],
+                                [
+                                    '_attributes' => [
+                                            'Code' => '*LF'
+                                        ],
+                                    '_cdata' => '1 lift '
+                                ],
+                                [
+                                    '_attributes' => [
+                                            'Code' => '*RS'
+                                        ],
+                                    '_cdata' => 'Room Service from 18:00 to 21:00 '
+                                ],
+                                [
+                                    '_attributes' => [
+                                            'Code' => '*IN'
+                                        ],
+                                    '_cdata' => 'Internet via television '
+                                ],
+                                [
+                                    '_attributes' => [
+                                            'Code' => '*AC'
+                                        ],
+                                    '_cdata' => 'Air conditioning '
+                                ],
+                            ]
+                    ]
+                ]
+            ]
         ];
     }
 }


### PR DESCRIPTION
Hi,

I used your package in my project and found a bug in it.

If in XML a parent has multiple childs nodes with same name, your package overwrites the value over and over due to the same name of those child nodes.

For example,

```xml
<RoomTypes RoomCount="79">
  <RoomType Code="SB">
    <![CDATA[ Single rooms ]]>
  </RoomType>
  <RoomType Code="DB">
    <![CDATA[ Double rooms ]]>
  </RoomType>
  <RoomType Code="TB">
    <![CDATA[ Twin rooms ]]>
  </RoomType>
  <RoomType Code="TR">
    <![CDATA[ Triple rooms ]]>
  </RoomType>
  <RoomType Code="NS">
    <![CDATA[ Non-smoking rooms ]]>
  </RoomType>
</RoomTypes>
``` 

So after using package's method we will get the following array:
```php
[RoomTypes] => Array
  ( 
    [_attributes] => Array
      (
        [RoomCount] => 79
      )
    [RoomType] => Array
      (
        [_attributes] => Array
        (
            [Code] => NS
        )
         [_cdata] =>  Non-smoking rooms
      )

)
```
[1NEW_91.xml.zip](https://github.com/vyuldashev/xml-to-array/files/1902152/1NEW_91.xml.zip)

Just attached the XML file you can test the issue with this file.

