### PR TITLE
Fixed issue with duplicate checker by using `array_count_values()` to determine if a node has the same name

### DIFF
--- a/src/XmlToArray.php
+++ b/src/XmlToArray.php
@@ -49,7 +49,6 @@ class XmlToArray
         $result = $this->convertAttributes($element->attributes);
 
         $sameNamesOccurrences = [];
-        $sameNodeNameIndexes = [];
 
         if ($element->childNodes->length > 1) {
             $childNodeNames = [];
@@ -67,11 +66,13 @@ class XmlToArray
 
                 continue;
             }
+
             if ($node instanceof DOMText) {
                 $result = $node->textContent;
 
                 continue;
             }
+
             if ($node instanceof DOMElement) {
                 $nodeName = $node->nodeName;
                 $hasSameName = array_key_exists($nodeName, $sameNamesOccurrences) && $sameNamesOccurrences[$nodeName] > 1;
@@ -81,19 +82,7 @@ class XmlToArray
                     continue;
                 }
 
-                // If we already have a child node with the same name, we need to increment
-                // and keep track of their index.
-
-                if (isset($sameNodeNameIndexes[$nodeName])) {
-                    $key = $sameNodeNameIndexes[$nodeName] + 1;
-                } else {
-                    $key = 0;
-                }
-
-                $result[$nodeName][$key] = $this->convertDomElement($node);
-                $sameNodeNameIndexes[$nodeName] = $key;
-
-                continue;
+                $result[$nodeName][] = $this->convertDomElement($node);
             }
         }
 

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -71,6 +71,9 @@ class XmlToArrayTest extends TestCase
     public function sameNameTest(array $array)
     {
         $xml = ArrayToXml::convert($array, 'items');
+
+        dd(XmlToArray::convert($xml));
+
         $this->assertSame(['items' => $array], XmlToArray::convert($xml));
     }
 

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -71,10 +71,6 @@ class XmlToArrayTest extends TestCase
     public function sameNameTest(array $array)
     {
         $xml = ArrayToXml::convert($array, 'items');
-        $convertedArr = XmlToArray::convert($xml);
-
-        dd($convertedArr);
-
         $this->assertSame(['items' => $array], XmlToArray::convert($xml));
     }
 
@@ -86,30 +82,30 @@ class XmlToArrayTest extends TestCase
                     'Facilities' => [
                         'Facility' => [
                             [
-                                '_attributes' => ['Code'=>'*EC'],
-                                '_cdata' =>  'Earliest check-in at 14:00',
+                                '_attributes' => ['Code' => '*EC'],
+                                '_cdata' => 'Earliest check-in at 14:00',
                             ],
                             [
-                                '_attributes' => ['Code'=>'*LF'],
-                                '_cdata' =>  '1 lift',
+                                '_attributes' => ['Code' => '*LF'],
+                                '_cdata' => '1 lift',
                             ],
                             [
-                                '_attributes' => ['Code'=>'*RS'],
-                                '_cdata' =>  'Room Service from 18:00 to 21:00',
+                                '_attributes' => ['Code' => '*RS'],
+                                '_cdata' => 'Room Service from 18:00 to 21:00',
                             ],
                         ],
-                        'Factories' => [
+                        'Locations' => [
                             [
-                                '_attributes' => ['Code'=>'*EC'],
-                                '_cdata' =>  'Earliest check-in at 14:00',
+                                '_attributes' => ['ShortCode' => 'GB'],
+                                '_cdata' => 'United Kingdom',
                             ],
                             [
-                                '_attributes' => ['Code'=>'*LF'],
-                                '_cdata' =>  '1 lift',
+                                '_attributes' => ['ShortCode' => 'USA'],
+                                '_cdata' => 'United States of America',
                             ],
                             [
-                                '_attributes' => ['Code'=>'*RS'],
-                                '_cdata' =>  'Room Service from 18:00 to 21:00',
+                                '_attributes' => ['ShortCode' => 'AMS'],
+                                '_cdata' => 'Amsterdam',
                             ],
                         ],
                     ],

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -72,6 +72,9 @@ class XmlToArrayTest extends TestCase
     {
         $xml = ArrayToXml::convert($array, 'items');
         $convertedArr = XmlToArray::convert($xml);
+
+        dd($convertedArr);
+
         $this->assertSame(['items' => $array], XmlToArray::convert($xml));
     }
 
@@ -82,6 +85,20 @@ class XmlToArrayTest extends TestCase
                 [
                     'Facilities' => [
                         'Facility' => [
+                            [
+                                '_attributes' => ['Code'=>'*EC'],
+                                '_cdata' =>  'Earliest check-in at 14:00',
+                            ],
+                            [
+                                '_attributes' => ['Code'=>'*LF'],
+                                '_cdata' =>  '1 lift',
+                            ],
+                            [
+                                '_attributes' => ['Code'=>'*RS'],
+                                '_cdata' =>  'Room Service from 18:00 to 21:00',
+                            ],
+                        ],
+                        'Factories' => [
                             [
                                 '_attributes' => ['Code'=>'*EC'],
                                 '_cdata' =>  'Earliest check-in at 14:00',

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -71,9 +71,6 @@ class XmlToArrayTest extends TestCase
     public function sameNameTest(array $array)
     {
         $xml = ArrayToXml::convert($array, 'items');
-
-        dd(XmlToArray::convert($xml));
-
         $this->assertSame(['items' => $array], XmlToArray::convert($xml));
     }
 


### PR DESCRIPTION
Hi @vyuldashev 👋

Thank you for this great little package, it's helped me massively with a project we've had to built quickly. I ran into a small issue however which was with some of the XML I was processing. One section of the XML had the following child nodes:

```<Products>
<Products>
<Products>
<ProductCount>
```

I found an issue where the `sameName` variable wouldn't be `true` because of the last `<ProductCount>` child node causing the `isHomogenous` method to return `false`. 

I have solved this issue by using `array_count_values` which will count up all of the occurrences of each of the duplicated nodes, and when it checks to see if a node already exists, we check the `$sameNamesOccurrences` array for duplicates. 

All tests are passing fine and it seems to work for my solution too. I hope you get a chance to review and potentially accept this PR! 🤓

Have a great day. ☀️