### PR TITLE
Handling `spatie/array-to-xml` Attributes and Multi-Dimensional Arrays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^7.1"
+    "php": "^7.1|^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5",

--- a/src/XmlToArray.php
+++ b/src/XmlToArray.php
@@ -76,8 +76,11 @@ class XmlToArray
                 continue;
             }
             if ($node instanceof DOMText) {
-                $result = $node->textContent;
-
+                if (empty($result)) {
+                    $result = $node->textContent;
+                } else {
+                    $result['_value'] = $node->textContent;
+                }
                 continue;
             }
             if ($node instanceof DOMElement) {

--- a/src/XmlToArray.php
+++ b/src/XmlToArray.php
@@ -79,7 +79,7 @@ class XmlToArray
             }
             if ($node instanceof DOMElement) {
                 if ($sameNames[$node->nodeName]) { // Truthy — When $sameNames['foo'] > 0
-                    if (!array_key_exists($node->nodeName, $result)) { // Setup $result['foo']
+                    if (! array_key_exists($node->nodeName, $result)) { // Setup $result['foo']
                         $result[$node->nodeName] = [];
                     }
 

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -44,7 +44,7 @@ class XmlToArrayTest extends TestCase
                     'bad_guy' => [
                         'name' => 'Sauron',
                         'weapon' => 'Evil Eye',
-                    ],
+                    ]
                 ],
             ],
             [
@@ -98,6 +98,39 @@ class XmlToArrayTest extends TestCase
                     ],
                 ],
             ],
+        ];
+    }
+
+    /** @dataProvider sameMultiDimensionalData
+     * @param array $array
+     * @test
+     */
+    public function sameMultiDimensionalTest(array $array)
+    {
+        $xml = ArrayToXml::convert($array, 'items');
+        $convertedArr = XmlToArray::convert($xml);
+        $this->assertSame(['items' => $array], XmlToArray::convert($xml));
+    }
+
+    public function sameMultiDimensionalData()
+    {
+        return [
+            [
+                [
+                    'Good_guys' => [
+                        'Guy' => [
+                            ['name' => 'Luke Skywalker', 'weapon' => 'Lightsaber'],
+                            ['name' => 'Captain America', 'weapon' => 'Shield'],
+                        ],
+                    ],
+                    'Bad_guys' => [
+                        'Guy' => [
+                            ['name' => 'Sauron', 'weapon' => 'Evil Eye'],
+                            ['name' => 'Darth Vader', 'weapon' => 'Lightsaber'],
+                        ],
+                    ]
+                ]
+            ]
         ];
     }
 }

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -12,7 +12,7 @@ class XmlToArrayTest extends TestCase
 {
     /**
      * @dataProvider data
-     * 
+     *
      * @param  array  $array
      */
     public function test(array $array)

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -10,7 +10,8 @@ use Vyuldashev\XmlToArray\XmlToArray;
 
 class XmlToArrayTest extends TestCase
 {
-    /** @dataProvider data
+    /**
+     * @dataProvider data
      * @param array $array
      */
     public function test(array $array)
@@ -44,7 +45,7 @@ class XmlToArrayTest extends TestCase
                     'bad_guy' => [
                         'name' => 'Sauron',
                         'weapon' => 'Evil Eye',
-                    ]
+                    ],
                 ],
             ],
             [
@@ -64,7 +65,8 @@ class XmlToArrayTest extends TestCase
         ];
     }
 
-    /** @dataProvider sameNameData
+    /**
+     * @dataProvider sameNameData
      * @param array $array
      * @test
      */
@@ -101,7 +103,8 @@ class XmlToArrayTest extends TestCase
         ];
     }
 
-    /** @dataProvider sameMultiDimensionalData
+    /**
+     * @dataProvider sameMultiDimensionalData
      * @param array $array
      * @test
      */
@@ -128,9 +131,9 @@ class XmlToArrayTest extends TestCase
                             ['name' => 'Sauron', 'weapon' => 'Evil Eye'],
                             ['name' => 'Darth Vader', 'weapon' => 'Lightsaber'],
                         ],
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
     }
 }

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -12,7 +12,8 @@ class XmlToArrayTest extends TestCase
 {
     /**
      * @dataProvider data
-     * @param array $array
+     * 
+     * @param  array  $array
      */
     public function test(array $array)
     {
@@ -67,7 +68,8 @@ class XmlToArrayTest extends TestCase
 
     /**
      * @dataProvider sameNameData
-     * @param array $array
+     *
+     * @param  array  $array
      * @test
      */
     public function sameNameTest(array $array)
@@ -105,7 +107,8 @@ class XmlToArrayTest extends TestCase
 
     /**
      * @dataProvider sameMultiDimensionalData
-     * @param array $array
+     *
+     * @param  array  $array
      * @test
      */
     public function sameMultiDimensionalTest(array $array)


### PR DESCRIPTION
## Problem

When 2 nodes have a text value, and differing attributes, currently we're simply discarding those attributes.

This is described in `spatie/array-to-xml` [here](https://github.com/spatie/array-to-xml#adding-attributes).

Notable:
```
<The_survivor house="Hogwarts">
    Harry Potter
</The_survivor>
```

> 

## Problem Example

```
$t = '<?xml version="1.0"?><root><Good_guy attr1="value"><name>Luke Skywalker</name><weapon>Lightsaber</weapon></Good_guy><Bad_guy><name>Sauron</name><weapon>Evil Eye</weapon></Bad_guy><The_survivor house="Hogwarts">Harry Potter</The_survivor></root>'
\Vyuldashev\XmlToArray\XmlToArray::convert($t);
```

Will result in 
```
[
    "root" => [
        "Good_guy" => [
            "_attributes" => [
                "attr1" => "value",
            ],
            "name" => "Luke Skywalker",
            "weapon" => "Lightsaber",
        ],
        "Bad_guy" => [
            "name" => "Sauron",
            "weapon" => "Evil Eye",
        ],
        "The_survivor" => "Harry Potter",
    ],
]
```

## Solution

Check to see if attributes have been set before replacing the value.


## Solution Result
```
[
    "root" => [
        "Good_guy" => [
            "_attributes" => [
                "attr1" => "value",
            ],
            "name" => "Luke Skywalker",
            "weapon" => "Lightsaber",
        ],
        "Bad_guy" => [
            "name" => "Sauron",
            "weapon" => "Evil Eye",
        ],
        "The_survivor" => [
            "_attributes" => [
                "house" => "Hogwarts",
            ],
            "_value" => "Harry Potter",
        ],
    ],
]
```
