### PR TITLE
fix: fixed interpretations with new lines and carrigage returns

### DIFF
--- a/src/XmlToArray.php
+++ b/src/XmlToArray.php
@@ -23,6 +23,8 @@ class XmlToArray
 
     public static function convert(string $xml): array
     {
+        $xml = trim(preg_replace('/\s\s+/', '', $xml));
+
         $converter = new static($xml);
 
         return $converter->toArray();

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -18,6 +18,7 @@ class XmlToArrayTest extends TestCase
     public function test(array $array)
     {
         $xml = ArrayToXml::convert($array, 'items');
+        
         $this->assertSame(['items' => $array], XmlToArray::convert($xml));
     }
 
@@ -75,8 +76,10 @@ class XmlToArrayTest extends TestCase
     public function sameNameTest(array $array)
     {
         $xml = ArrayToXml::convert($array, 'items');
+
         $convertedArr = XmlToArray::convert($xml);
-        $this->assertSame(['items' => $array], XmlToArray::convert($xml));
+
+        $this->assertSame(['items' => $array], $convertedArr);
     }
 
     public function sameNameData()
@@ -114,8 +117,10 @@ class XmlToArrayTest extends TestCase
     public function sameMultiDimensionalTest(array $array)
     {
         $xml = ArrayToXml::convert($array, 'items');
+
         $convertedArr = XmlToArray::convert($xml);
-        $this->assertSame(['items' => $array], XmlToArray::convert($xml));
+
+        $this->assertSame(['items' => $array], $convertedArr);
     }
 
     public function sameMultiDimensionalData()
@@ -138,5 +143,44 @@ class XmlToArrayTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    /**
+     *  @dataProvider sameMultiDimensionalData
+     *  @test 
+     */
+    public function convert_WhenXmlHasNewLinesAndCarrigageReturns_ShouldCorrectConvertToArray(array $array)
+    {
+        $xml = "
+        <?xml version=\"1.0\"?> \r\n
+        <root> \r\n
+            <Good_guys> \r\n
+                <Guy> \r\n
+                    <name>Luke Skywalker</name> \r\n
+                    <weapon>Lightsaber</weapon> \r\n
+                </Guy> \r\n
+                <Guy> \r\n
+                    <name>Captain America</name> \r\n
+                    <weapon>Shield</weapon> \r\n
+                </Guy> \r\n
+            </Good_guys> \r\n
+            <Bad_guys> \r\n
+                <Guy> \r\n
+                    <name>Sauron</name> \r\n
+                    <weapon>Evil Eye</weapon> \r\n
+                </Guy> \r\n
+                <Guy> \r\n
+                    <name>Darth Vader</name> \r\n
+                    <weapon>Lightsaber</weapon> \r\n
+                </Guy> \r\n
+            </Bad_guys> \r\n
+        </root>
+        ";
+
+        $arrayExpected['root'] = $array;
+
+        $convertedArr = XmlToArray::convert($xml);
+
+        $this->assertSame($arrayExpected, $convertedArr);
     }
 }

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -18,7 +18,7 @@ class XmlToArrayTest extends TestCase
     public function test(array $array)
     {
         $xml = ArrayToXml::convert($array, 'items');
-        
+
         $this->assertSame(['items' => $array], XmlToArray::convert($xml));
     }
 
@@ -71,6 +71,7 @@ class XmlToArrayTest extends TestCase
      * @dataProvider sameNameData
      *
      * @param  array  $array
+     * 
      * @test
      */
     public function sameNameTest(array $array)
@@ -112,6 +113,7 @@ class XmlToArrayTest extends TestCase
      * @dataProvider sameMultiDimensionalData
      *
      * @param  array  $array
+     * 
      * @test
      */
     public function sameMultiDimensionalTest(array $array)
@@ -147,6 +149,7 @@ class XmlToArrayTest extends TestCase
 
     /**
      *  @dataProvider sameMultiDimensionalData
+     * 
      *  @test 
      */
     public function convert_WhenXmlHasNewLinesAndCarrigageReturns_ShouldCorrectConvertToArray(array $array)

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -71,6 +71,7 @@ class XmlToArrayTest extends TestCase
      * @dataProvider sameNameData
      *
      * @param  array  $array
+     *
      * @test
      */
     public function sameNameTest(array $array)
@@ -112,6 +113,7 @@ class XmlToArrayTest extends TestCase
      * @dataProvider sameMultiDimensionalData
      *
      * @param  array  $array
+     *
      * @test
      */
     public function sameMultiDimensionalTest(array $array)
@@ -147,7 +149,8 @@ class XmlToArrayTest extends TestCase
 
     /**
      *  @dataProvider sameMultiDimensionalData
-     *  @test 
+     *
+     *  @test
      */
     public function convert_WhenXmlHasNewLinesAndCarrigageReturns_ShouldCorrectConvertToArray(array $array)
     {

--- a/tests/XmlToArrayTest.php
+++ b/tests/XmlToArrayTest.php
@@ -71,7 +71,6 @@ class XmlToArrayTest extends TestCase
      * @dataProvider sameNameData
      *
      * @param  array  $array
-     * 
      * @test
      */
     public function sameNameTest(array $array)
@@ -113,7 +112,6 @@ class XmlToArrayTest extends TestCase
      * @dataProvider sameMultiDimensionalData
      *
      * @param  array  $array
-     * 
      * @test
      */
     public function sameMultiDimensionalTest(array $array)
@@ -149,7 +147,6 @@ class XmlToArrayTest extends TestCase
 
     /**
      *  @dataProvider sameMultiDimensionalData
-     * 
      *  @test 
      */
     public function convert_WhenXmlHasNewLinesAndCarrigageReturns_ShouldCorrectConvertToArray(array $array)


### PR DESCRIPTION
Hello everyone!
I fixed the xml parse which can contain newline and carriage return.
Problem was resolve by user [ondrejsanetrnik](https://github.com/ondrejsanetrnik) and I decided to implement the fix to the package.
Link to the issue no. 2 where ondrejsanetrnik proposed a solution to the problem: https://github.com/vyuldashev/xml-to-array/issues/2#issuecomment-668564510